### PR TITLE
Update go (commands)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -484,12 +484,14 @@ RUN \
     mkdir -p /temp/peass
 
 WORKDIR /temp/peass
+
 RUN \
-    wget -q https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite/raw/master/winPEAS/winPEASexe/binaries/Obfuscated%20Releases/winPEASany.exe && \
-    wget -q https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite/raw/master/winPEAS/winPEASexe/binaries/Obfuscated%20Releases/winPEASx64.exe && \
-    wget -q https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite/raw/master/winPEAS/winPEASexe/binaries/Obfuscated%20Releases/winPEASx86.exe && \
-    wget -q https://raw.githubusercontent.com/carlospolop/privilege-escalation-awesome-scripts-suite/master/winPEAS/winPEASbat/winPEAS.bat && \
-    wget -q https://raw.githubusercontent.com/carlospolop/privilege-escalation-awesome-scripts-suite/master/linPEAS/linpeas.sh
+    latest_release_url=$(curl --silent --head https://github.com/carlospolop/PEASS-ng/releases/latest | grep "location:" | cut -d" " -f2- | sed "s/tag/download/" | tr -d '\r') && \
+    wget -q "${latest_release_url}/winPEASany.exe" && \
+    wget -q "${latest_release_url}/winPEASx64.exe" && \
+    wget -q "${latest_release_url}/winPEASx86.exe" && \
+    wget -q "${latest_release_url}/winPEAS.bat" && \
+    wget -q "${latest_release_url}/linpeas.sh"
 
 # Install smbmap
 WORKDIR /temp
@@ -560,7 +562,8 @@ RUN \
 # Download Pass-the-Hash
     git clone --depth 1 https://github.com/byt3bl33d3r/pth-toolkit.git && \
 # Download Mimikatz
-    wget --quiet https://github.com/gentilkiwi/mimikatz/releases/download/2.2.0-20200816/mimikatz_trunk.zip -O mimikatz.zip && \
+    latest_release_url=$(curl --silent --head https://github.com/gentilkiwi/mimikatz/releases/latest | grep "location:" | cut -d" " -f2- | sed "s/tag/download/" | tr -d '\r') && \
+    wget -q "${latest_release_url}/mimikatz_trunk.zip" -O mimikatz.zip && \
     unzip mimikatz.zip -d mimikatz && \
     rm mimikatz.zip && \
     mkdir netcat && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,9 +129,7 @@ RUN \
 # Install go
 WORKDIR /tmp
 RUN \
-# Update from 1.15.5 to 1.16.2
-#    wget -q https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz -O go.tar.gz && \
-    wget -q https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz -O go.tar.gz && \
+    wget -q https://go.dev/dl/go1.17.8.linux-amd64.tar.gz -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
 # Install aws-cli
     curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
@@ -257,23 +255,23 @@ WORKDIR /tools/recon
 
 # Install gobuster
 RUN \
-    go get github.com/OJ/gobuster && \
+    go install github.com/OJ/gobuster@latest && \
 # Install tojson
-    go get -u github.com/tomnomnom/hacks/tojson && \
+    go install github.com/tomnomnom/hacks/tojson@latest && \
 # Install gowitness
     ln -s /tools/recon/gowitness/gowitness /usr/bin/gowitness && \
 # Install subjack
-    go get github.com/haccer/subjack && \
+    go install github.com/haccer/subjack@latest && \
 # Install SubOver 
-    go get github.com/Ice3man543/SubOver && \
+    go install github.com/Ice3man543/SubOver@latest && \
 # Install tko-subs
-    go get github.com/anshumanbh/tko-subs && \
+    go install github.com/anshumanbh/tko-subs@latest && \
 # Install hakcheckurl
-    go get github.com/hakluke/hakcheckurl && \
+    go install github.com/hakluke/hakcheckurl@latest && \
 # Install haktldextract
-    go get github.com/hakluke/haktldextract && \
+    go install github.com/hakluke/haktldextract@latest && \
 # Install gotop
-    go get github.com/cjbassi/gotop && \
+    go install github.com/cjbassi/gotop@latest && \
 # Install aquatone
     ln -s /tools/recon/aquatone/aquatone /usr/bin/aquatone && \
 # Install knock
@@ -289,23 +287,23 @@ RUN \
 # Install subjs
     ln -s /tools/recon/subjs/subjs /usr/bin/subjs && \
 # Install otxurls
-    go get github.com/lc/otxurls && \
+    go install github.com/lc/otxurls@latest && \
 # Install amass
     ln -s /tools/recon/amass/amass_linux_amd64/amass /usr/bin/amass && \
 # Install hakrevdns
-    go get github.com/hakluke/hakrevdns && \
+    go install github.com/hakluke/hakrevdns@latest && \
 # Install ffuf
-    go get github.com/ffuf/ffuf && \
+    go install github.com/ffuf/ffuf@latest && \
 # Install httprobe
-    go get -u github.com/tomnomnom/httprobe && \
+    go install github.com/tomnomnom/httprobe@latest && \
 # Install hakrawler
-    go get github.com/hakluke/hakrawler && \
+    go install github.com/hakluke/hakrawler@latest && \
 # Install waybackurls
-    go get github.com/tomnomnom/waybackurls && \
+    go install github.com/tomnomnom/waybackurls@latest && \
 # Download gospider
-    go get -u github.com/jaeles-project/gospider && \
+    go install github.com/jaeles-project/gospider@latest && \
 # Download getJS
-    go get github.com/003random/getJS && \
+    go install github.com/003random/getJS@latest && \
 # Install findomain
     ln -s /tools/recon/findomain/findomain /usr/bin/findomain && \
 # Install subfinder
@@ -403,7 +401,7 @@ FROM builder4 as builder5
 COPY --from=owasp /temp/ /tools/owasp/
 # Install kxss
 RUN \
-    go get github.com/tomnomnom/hacks/kxss && \
+    go install github.com/tomnomnom/hacks/kxss@latest && \
 # Install dalfox
     ln -s /tools/owasp/dalfox/dalfox /usr/bin/dalfox && \
 # Install jaeles
@@ -608,7 +606,7 @@ WORKDIR /tools/otherResources
 RUN \
     git clone --depth 1 https://github.com/gwen001/pentest-tools.git && \
 # Download qsreplace
-    go get -u github.com/tomnomnom/qsreplace
+    go install github.com/tomnomnom/qsreplace@latest
 
 # Install nuclei
 RUN \


### PR DESCRIPTION
nuclei meanwhile requires at least go 1.17 (see https://github.com/projectdiscovery/nuclei#install-nuclei). this breaks the build again... updated to go 1.17 and fixed deprecated `go get ...` commands.